### PR TITLE
Fix: Break on asyncio.CancelledError in NullMonitor

### DIFF
--- a/src/rf_survey/monitor.py
+++ b/src/rf_survey/monitor.py
@@ -433,4 +433,4 @@ class NullZmsMonitor:
             try:
                 await asyncio.sleep(10)
             except asyncio.CancelledError:
-                pass
+                break


### PR DESCRIPTION
Was passing which then did not exit correctly. 